### PR TITLE
WIP join team

### DIFF
--- a/functions/conversation.js
+++ b/functions/conversation.js
@@ -43,6 +43,19 @@ exports.detectIntent = (message) => {
             break
       }
     } 
+    // detect a join message
+    if ('speechAct' in message && message.speechAct === "join") {
+      // join is a special speech-act - 
+      // it flips the subject-entity-type & subject-entity-id with the object-entity-type & object-entity-id
+      // also, it changes the context of the team -
+      // it writes the message in the team the user tries to join
+      // TODO clean this! - protocol shouldn't have magic
+      intent.teamId = intent.entityId
+      intent.objectEntityType = intent.entityType
+      intent.objectEntityId = intent.entityId
+      intent.entityType = "member"
+      intent.entityId = message.user
+    }
     if (intent.entityType in ENTITIES_METADATA) {
         intent.metadataFound = true
     }

--- a/functions/conversation.js
+++ b/functions/conversation.js
@@ -49,7 +49,7 @@ exports.detectIntent = (message) => {
       // it flips the subject-entity-type & subject-entity-id with the object-entity-type & object-entity-id
       // also, it changes the context of the team -
       // it writes the message in the team the user tries to join
-      // TODO clean this! - protocol shouldn't have magic
+      // TODO add metadata-based "macros" to the protocol, allowing friendly ways to say things
       intent.teamId = intent.entityId
       intent.objectEntityType = intent.entityType
       intent.objectEntityId = intent.entityId

--- a/functions/entities.js
+++ b/functions/entities.js
@@ -67,6 +67,7 @@ const SINGLE_ATTRIBUTE_STATES = [
     "suggested",
     "added",
     "invited",
+    "asked-to-join",
     "discussed",
     "approved",
     "declined",
@@ -86,8 +87,12 @@ const SINGLE_ATTRIBUTE_STATES = [
       from: [],
       to: "invited"
     },
+    "join": {
+      from: [],
+      to: "asked-to-join"
+    },
     "discuss": {
-      from: ["suggested", "invited"],
+      from: ["suggested", "invited", "asked-to-join"],
       to: "discussed"
     },
     "approve": {
@@ -95,7 +100,7 @@ const SINGLE_ATTRIBUTE_STATES = [
       to: "approved"
     },
     "decline": {
-      from: ["invited", "discussed", "approved"],
+      from: ["asked-to-join", "invited", "discussed", "approved"],
       to: "declined"
     },
     "delete": {

--- a/src/containers/FromTeal/FromTeal.js
+++ b/src/containers/FromTeal/FromTeal.js
@@ -56,13 +56,10 @@ class FromTeal extends Component {
           <div className="container">
             <img src={dibauAvatar} alt="Avatar"/>
             <p>
-              Hi, my name is Udi.
-              Every now & then, my mind comes up with ideas for new
-              projects. I really want to build these projects, but
-              it usually takes more than one person to build something
-              that's really great. So, I decided to build an app to help people like me to
-              <strong> team-up with like-minded people</strong> in order to
-              <strong> realize their dream projects</strong>. See how it works:
+            Every person in this world is valuable. We all have ideas &amp; skills to create value for others.
+            No person is more important than any other &amp; everyone have the right to be free to work on what they love, without anyone telling them what to do &amp; what to work on.
+            <br/>
+            <strong>fromTeal</strong> is helping people to create <strong>Teal Organizations</strong> - teams of people with shared purpose, working together as equal partners to achieve their purpose.
             </p>
 
             <iframe style={iframeStyle} width="500" height="350" src="//speakerdeck.com/player/7b754d59b56446598afccdf8c56de28c"/>

--- a/src/containers/FromTeal/TeamChannel/TeamChannel.js
+++ b/src/containers/FromTeal/TeamChannel/TeamChannel.js
@@ -24,6 +24,7 @@ class TeamChannel extends Component {
       "invite",
       "add",
       "create",
+      "join",
       // the following aren't supported yet
       // "apply",
       // "deactivate",


### PR DESCRIPTION
### Why
* Enable users to join a team

### What
* Added a `join` speech-act
* Message syntax is: [join team X]
* Handle the transformations needed to support this syntax - this syntax is basically a case of a "macro": a friendly way to say something, that behind the scenes is translated to the proper way to say it. **_Since macros are useful, there should be a standard way to encode them, so that they're not part of the basic protocol_**.
* Adds the user as new member of the team he asked to join, in status: `asked-to-join`
* Send a message to the team the user asked to join
* Send a message to the user informing it that the team was notified