### PR TITLE
[Trello-76] Love to message input component

### DIFF
--- a/functions/conversation.js
+++ b/functions/conversation.js
@@ -3,6 +3,17 @@ const _ = require('lodash')
 const textUtils = require('./text_utils')
 
 
+exports.normalizedMessage = (message) => {
+  const normalizedMessage = {...message}
+  if ('speechAct' in message) {
+    normalizedMessage.speechAct = message.speechAct.toLowerCase()
+  }
+  if ('entityType' in message) {
+    normalizedMessage.entityType = message.entityType.toLowerCase()
+  }
+  return normalizedMessage
+}
+
 exports.detectIntent = (message) => {
     const intent = {}
     intent.basicIntent = ''

--- a/functions/index.js
+++ b/functions/index.js
@@ -94,7 +94,8 @@ async function messageHandler(snap, context) {
     console.log(`Yay, invoked: '${JSON.stringify(message)}'`)
     const triggeringMessageId = context.params.documentId
 
-    const msgIntent = conversation.detectIntent(message)    
+    const normalizedMessage = conversation.normalizedMessage(message)
+    const msgIntent = conversation.detectIntent(normalizedMessage)    
     const teamId = (!_.isEmpty(msgIntent.teamId)) ? msgIntent.teamId : context.params.teamId
 
     console.log(`Message basic intent: ${msgIntent.basicIntent}`)

--- a/functions/index.js
+++ b/functions/index.js
@@ -27,6 +27,14 @@ admin.initializeApp({
 });
 const db = admin.firestore();
 
+
+exports.getEntitiesMetadata = functions.https.onRequest((req, res) => {
+    cors(req, res, () => {
+        return res.send(ENTITIES_METADATA)
+    })
+})
+
+
 exports.getMyTeams = functions.https.onRequest((req, res) => {
     cors(req, res, () => {
         const idToken = req.header('me')

--- a/functions/index.js
+++ b/functions/index.js
@@ -333,6 +333,9 @@ exports.handleEntityCreatedEvent = functions.pubsub.topic('entity_created')
     // - only on confirmation we would start the search for matching teams
     message = message.json
     console.log(message)
+    // update the ids table
+    const ref = db.collection(`ids/${message.entityType}/${message.teamId}`)
+    await ref.doc(message.entityId).set({id: message.entityId, text: message.entityId})
     if (message.speechAct === 'suggest' && message.entityType === 'purpose') {
         console.log(`Handling purpose creation for team: ${message.teamId}`)
         const team = await fetchTeam(message.teamId)

--- a/functions/index.js
+++ b/functions/index.js
@@ -334,8 +334,12 @@ exports.handleEntityCreatedEvent = functions.pubsub.topic('entity_created')
     message = message.json
     console.log(message)
     // update the ids table
-    const ref = db.collection(`ids/${message.entityType}/${message.teamId}`)
-    await ref.doc(message.entityId).set({id: message.entityId, text: message.entityId})
+    const ref = db.collection(`ids/by_team/${message.teamId}`)
+    await ref.doc(message.entityId).set({
+        id: message.entityId, 
+        entityType: message.entityType, 
+        text: _.get(message, 'text', message.entityId)
+    })
     if (message.speechAct === 'suggest' && message.entityType === 'purpose') {
         console.log(`Handling purpose creation for team: ${message.teamId}`)
         const team = await fetchTeam(message.teamId)

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.css
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.css
@@ -12,13 +12,13 @@
 
 .ChatInput select {
     vertical-align: top;
-    background-color: lightblue;
+    /* background-color: lightblue; */
     font-size: 1.1rem;
 }
 
 .ChatInput input {
     vertical-align: top;
-    background-color: lightblue;
+    /* background-color: lightblue; */
     font-size: 1.1rem;
 /*    background-color: #008080;
     color: white;

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
@@ -21,6 +21,9 @@ class ChatInput extends Component {
     const teamId = this.props.teamId
     this.props.addMessage(text, teamId)
     this.messageText.current.value = ""
+    this.speechActSelect.current.value = ""
+    this.entityTypeSelect.current.value = ""
+    this.entityIdSelect.current.value = ""
     this.highlightProtocolMessage()
   }
 
@@ -100,7 +103,7 @@ class ChatInput extends Component {
           </select>
           <select ref={this.entityIdSelect} onChange={this.handleEntityIdSelection}>
             <option key="" value="">(Entity Id)</option>
-            {_.get(this.props.idsByType, this.state.selectedEntityType, []).map((id, i) => (<option key={id.id} value={id.id}>{id.id} - {id.text}</option>))}
+            {_.get(this.props.idsByType, this.state.selectedEntityType, []).map((id, i) => (<option key={id.id} value={id.id}>{id.id} - {_.truncate(id.text)}</option>))}
           </select>
         </div>
       </div>

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
@@ -29,6 +29,7 @@ class ChatInput extends Component {
       // parsed successfully
       this.setState({isProtocolMessage: true})
     } catch (e) {
+      // console.log(e)
       // not parsed successfully
       this.setState({isProtocolMessage: false})
     }  

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
@@ -15,7 +15,7 @@ class ChatInput extends Component {
     const entityId = this.entityIdInput.current.value
     const text = this.messageText.current.value
     const teamId = this.props.teamId
-    this.props.addMessage(speechAct, entityType, entityId, text, teamId)
+    this.props.addMessage(text, teamId, speechAct, entityType, entityId)
     this.messageText.current.value = ""
     this.entityIdInput.current.value = ""
   }

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import {parse} from '../../../../protocols/entityChat'
 
@@ -7,11 +8,12 @@ import Classes from './ChatInput.css'
 class ChatInput extends Component {
   speechActSelect = React.createRef()
   entityTypeSelect = React.createRef()
-  entityIdInput = React.createRef()
+  entityIdSelect = React.createRef()
   messageText = React.createRef()
 
   state = {
-    isProtocolMessage: false
+    isProtocolMessage: false,
+    selectedEntityType: ""
   }
 
   sendHandler = () => {
@@ -19,7 +21,6 @@ class ChatInput extends Component {
     const teamId = this.props.teamId
     this.props.addMessage(text, teamId)
     this.messageText.current.value = ""
-    this.entityIdInput.current.value = ""
     this.highlightProtocolMessage()
   }
 
@@ -49,6 +50,7 @@ class ChatInput extends Component {
 
   handleEntityTypeSelection = () => {
     const entityType = this.entityTypeSelect.current.value
+    this.setState({selectedEntityType: entityType})
     const parts = this.messageText.current.value.split(" ")
     if (parts) {
       // TODO fix - won't work well if using more than 1 space
@@ -58,6 +60,18 @@ class ChatInput extends Component {
     } else {
       this.messageText.current.value = entityType
     }
+    this.highlightProtocolMessage()
+  }
+
+  handleEntityIdSelection = () => {
+    const entityId = this.entityIdSelect.current.value
+    const parts = this.messageText.current.value.split(" ")
+    const newParts = []
+    if (parts.length > 0) newParts.push(parts[0])   // speechAct
+    if (parts.length > 1) newParts.push(parts[1])   // entityType
+    newParts.push(entityId)
+    if (parts.length > 3) newParts.push(parts.slice(3, parts.length).join(" "))   // rest
+    this.messageText.current.value = newParts.join(" ")
     this.highlightProtocolMessage()
   }
 
@@ -84,7 +98,10 @@ class ChatInput extends Component {
             <option key="" value="">(Entity type)</option>
           {this.props.entityTypes.map((entityType, i) => (<option key={entityType} value={entityType}>{entityType}</option>))}
           </select>
-          <input type="text" placeholder="(Entity id)" ref={this.entityIdInput}/>
+          <select ref={this.entityIdSelect} onChange={this.handleEntityIdSelection}>
+            <option key="" value="">(Entity Id)</option>
+            {_.get(this.props.idsByType, this.state.selectedEntityType, []).map((id, i) => (<option key={id.id} value={id.id}>{id.id} - {id.text}</option>))}
+          </select>
         </div>
       </div>
     )

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
@@ -15,14 +15,12 @@ class ChatInput extends Component {
   }
 
   sendHandler = () => {
-    const speechAct = this.speechActSelect.current.value
-    const entityType = this.entityTypeSelect.current.value
-    const entityId = this.entityIdInput.current.value
     const text = this.messageText.current.value
     const teamId = this.props.teamId
-    this.props.addMessage(text, teamId, speechAct, entityType, entityId)
+    this.props.addMessage(text, teamId)
     this.messageText.current.value = ""
     this.entityIdInput.current.value = ""
+    this.highlightProtocolMessage()
   }
 
   highlightProtocolMessage = () => {
@@ -36,23 +34,56 @@ class ChatInput extends Component {
     }  
   }
 
+  handleSpeechActSelection = () => {
+    const speechAct = this.speechActSelect.current.value
+    const parts = this.messageText.current.value.split(" ")
+    if (parts) {
+      // TODO fix - won't work well if using more than 1 space
+      this.messageText.current.value = speechAct + " " + parts.slice(1, parts.length).join(" ")
+    } else {
+      this.messageText.current.value = speechAct + " "
+    }
+    this.highlightProtocolMessage()
+  }
+
+  handleEntityTypeSelection = () => {
+    const entityType = this.entityTypeSelect.current.value
+    const parts = this.messageText.current.value.split(" ")
+    if (parts) {
+      // TODO fix - won't work well if using more than 1 space
+      const speechAct = parts[0]
+      const rest = parts.length > 2 ? " " + parts.slice(2, parts.length).join(" ") : ""
+      this.messageText.current.value = speechAct + " " + entityType + rest
+    } else {
+      this.messageText.current.value = entityType
+    }
+    this.highlightProtocolMessage()
+  }
+
+  handleKeyPressed = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault()
+      this.sendHandler()
+    }
+  }
+
   render() {
-    const textStyle = this.state.isProtocolMessage ? {backgroundColor: 'lightblue'} : {}
+    const textInputColor = this.state.isProtocolMessage ? {backgroundColor: 'lightblue'} : {}
+    const textStyle = {...textInputColor, width: '99%'}
     return (
       <div className={'ChatInput'}>
         <div className={'InputForm'}>
-          <select ref={this.speechActSelect}>
+          <textarea ref={this.messageText} placeholder="Your message" rows="3" onChange={this.highlightProtocolMessage} onKeyPress={this.handleKeyPressed} style={textStyle}></textarea>
+          <br/>
+          <select ref={this.speechActSelect} onChange={this.handleSpeechActSelection}>
             <option key="" value="">(Action)</option>
           {this.props.speechActs.map((speechAct, i) => (<option key={speechAct} value={speechAct}>{speechAct}</option>))}
           </select>
-          <select ref={this.entityTypeSelect}>
+          <select ref={this.entityTypeSelect} onChange={this.handleEntityTypeSelection}>
             <option key="" value="">(Entity type)</option>
           {this.props.entityTypes.map((entityType, i) => (<option key={entityType} value={entityType}>{entityType}</option>))}
           </select>
           <input type="text" placeholder="(Entity id)" ref={this.entityIdInput}/>
-          <br/>
-          <textarea ref={this.messageText} placeholder="Your message" rows="3" onChange={this.highlightProtocolMessage} style={textStyle}></textarea>
-          <button className="SendButton" onClick={this.sendHandler}>Send</button>
         </div>
       </div>
     )

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import {parse} from '../../../../protocols/entityChat'
 
 import Classes from './ChatInput.css'
 
@@ -8,6 +9,10 @@ class ChatInput extends Component {
   entityTypeSelect = React.createRef()
   entityIdInput = React.createRef()
   messageText = React.createRef()
+
+  state = {
+    isProtocolMessage: false
+  }
 
   sendHandler = () => {
     const speechAct = this.speechActSelect.current.value
@@ -20,7 +25,19 @@ class ChatInput extends Component {
     this.entityIdInput.current.value = ""
   }
 
+  highlightProtocolMessage = () => {
+    try {
+      parse(this.messageText.current.value)
+      // parsed successfully
+      this.setState({isProtocolMessage: true})
+    } catch (e) {
+      // not parsed successfully
+      this.setState({isProtocolMessage: false})
+    }  
+  }
+
   render() {
+    const textStyle = this.state.isProtocolMessage ? {backgroundColor: 'lightblue'} : {}
     return (
       <div className={'ChatInput'}>
         <div className={'InputForm'}>
@@ -34,7 +51,7 @@ class ChatInput extends Component {
           </select>
           <input type="text" placeholder="(Entity id)" ref={this.entityIdInput}/>
           <br/>
-          <textarea ref={this.messageText} placeholder="Your message" rows="3"></textarea>
+          <textarea ref={this.messageText} placeholder="Your message" rows="3" onChange={this.highlightProtocolMessage} style={textStyle}></textarea>
           <button className="SendButton" onClick={this.sendHandler}>Send</button>
         </div>
       </div>

--- a/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
+++ b/src/containers/FromTeal/Chat/ChatInput/ChatInput.js
@@ -13,6 +13,7 @@ class ChatInput extends Component {
 
   state = {
     isProtocolMessage: false,
+    selectedSpeechAct: "",
     selectedEntityType: ""
   }
 
@@ -41,6 +42,7 @@ class ChatInput extends Component {
 
   handleSpeechActSelection = () => {
     const speechAct = this.speechActSelect.current.value
+    this.setState({selectedSpeechAct: speechAct})
     const parts = this.messageText.current.value.split(" ")
     if (parts) {
       // TODO fix - won't work well if using more than 1 space
@@ -99,7 +101,7 @@ class ChatInput extends Component {
           </select>
           <select ref={this.entityTypeSelect} onChange={this.handleEntityTypeSelection}>
             <option key="" value="">(Entity type)</option>
-          {this.props.entityTypes.map((entityType, i) => (<option key={entityType} value={entityType}>{entityType}</option>))}
+            {_.get(this.props.entityTypesBySpeechAct, this.state.selectedSpeechAct, []).map((entityType, i) => (<option key={entityType} value={entityType}>{entityType}</option>))}
           </select>
           <select ref={this.entityIdSelect} onChange={this.handleEntityIdSelection}>
             <option key="" value="">(Entity Id)</option>

--- a/src/containers/FromTeal/Chat/ChatMessage/ChatMessage.css
+++ b/src/containers/FromTeal/Chat/ChatMessage/ChatMessage.css
@@ -9,3 +9,14 @@
   background-color: lightblue;
   font-size: 1.1rem;
 }
+
+.ChatMessageTime {
+  color: #999;
+  font-size: 0.8rem;
+}
+
+.SpeechActRight {
+  float: right;
+  background-color: lightblue;
+  font-size: 1.1rem;
+ }

--- a/src/containers/FromTeal/Chat/ChatMessage/ChatMessage.js
+++ b/src/containers/FromTeal/Chat/ChatMessage/ChatMessage.js
@@ -47,8 +47,8 @@ class ChatMessage extends Component {
     return (
         <div className={'container'}>
           <img src={this.props.userPicture} alt={this.props.userName}></img>
-          <strong>{this.props.userName}</strong><br/>
-          <span className={'SpeechAct'}>{this.props.speechAct} {this.props.entityType} {this.props.entityId}</span>
+          <strong>{this.props.userName}</strong>: <span className={'SpeechAct'}>{this.props.speechAct} {this.props.entityType} {this.props.entityId}</span>
+          <br/>
           {message}
           <span className="time-right">{this.props.created.toDate().toLocaleString()}</span>
         </div>

--- a/src/containers/FromTeal/Chat/ChatMessage/ChatMessage.js
+++ b/src/containers/FromTeal/Chat/ChatMessage/ChatMessage.js
@@ -47,10 +47,9 @@ class ChatMessage extends Component {
     return (
         <div className={'container'}>
           <img src={this.props.userPicture} alt={this.props.userName}></img>
-          <strong>{this.props.userName}</strong>: <span className={'SpeechAct'}>{this.props.speechAct} {this.props.entityType} {this.props.entityId}</span>
-          <br/>
+          <span className={'SpeechActRight'}>{this.props.speechAct}  {this.props.entityType} {this.props.entityId}</span>
+          <strong>{this.props.userName}</strong> <span className="ChatMessageTime">{this.props.created.toDate().toLocaleString()}</span><br/>
           {message}
-          <span className="time-right">{this.props.created.toDate().toLocaleString()}</span>
         </div>
     )
   }

--- a/src/containers/FromTeal/FromTeal.js
+++ b/src/containers/FromTeal/FromTeal.js
@@ -58,8 +58,11 @@ class FromTeal extends Component {
             <p>
             Every person in this world is valuable. We all have ideas &amp; skills to create value for others.
             No person is more important than any other &amp; everyone have the right to be free to work on what they love, without anyone telling them what to do &amp; what to work on.
-            <br/>
-            <strong>fromTeal</strong> is helping people to create <strong>Teal Organizations</strong> - teams of people with shared purpose, working together as equal partners to achieve their purpose.
+            <br/><br/>
+            <strong>fromTeal</strong> is helping people to create <strong><a href="https://en.wikipedia.org/wiki/Teal_organisation">Teal Organizations</a></strong> - teams of people with shared purpose, working together as equal partners to achieve their purpose.
+            If you've ever been to a Hackathon - then you experienced what's it like to work in a Teal Organization & how much it's more effective than any other type of organization.
+            <br/><br/>
+            Here's how fromTeal works:
             </p>
 
             <iframe style={iframeStyle} width="500" height="350" src="//speakerdeck.com/player/7b754d59b56446598afccdf8c56de28c"/>

--- a/src/containers/FromTeal/TeamChannel/TeamChannel.js
+++ b/src/containers/FromTeal/TeamChannel/TeamChannel.js
@@ -87,7 +87,16 @@ class TeamChannel extends Component {
         });
   }
 
-  addMessage = (speechAct, entityType, entityId, text, teamId) => {
+  parseMessage = (text, speechAct, entityType, entityId) => {
+    
+
+    return {text, speechAct, entityType, entityId}
+  }
+
+  addMessage = (text, teamId, speechAct=null, entityType=null, entityId=null) => {
+    if (speechAct == null || entityType == null) {
+      ({text, speechAct, entityType, entityId} = parseMessage(text, speechAct, entityType, entityId))
+    }
     const newMessage = {
       type: "text-message",
       text: text,

--- a/src/protocols/entityChat.js
+++ b/src/protocols/entityChat.js
@@ -122,14 +122,6 @@
   };
   inherit(TreeNode8, TreeNode);
 
-  var TreeNode9 = function(text, offset, elements) {
-    TreeNode.apply(this, arguments);
-    this['speechAct_show'] = elements[0];
-    this['__'] = elements[1];
-    this['entityType'] = elements[2];
-  };
-  inherit(TreeNode9, TreeNode);
-
   var FAILURE = {};
 
   var Grammar = {
@@ -163,13 +155,9 @@
                   address0 = this._read_msg_list();
                   if (address0 === FAILURE) {
                     this._offset = index1;
-                    address0 = this._read_msg_show_entity();
+                    address0 = this._read_msg_show();
                     if (address0 === FAILURE) {
                       this._offset = index1;
-                      address0 = this._read_msg_show();
-                      if (address0 === FAILURE) {
-                        this._offset = index1;
-                      }
                     }
                   }
                 }
@@ -919,10 +907,10 @@
       return address0;
     },
 
-    _read_msg_show_entity: function() {
+    _read_msg_show: function() {
       var address0 = FAILURE, index0 = this._offset;
-      this._cache._msg_show_entity = this._cache._msg_show_entity || {};
-      var cached = this._cache._msg_show_entity[index0];
+      this._cache._msg_show = this._cache._msg_show || {};
+      var cached = this._cache._msg_show[index0];
       if (cached) {
         this._offset = cached[1];
         return cached[0];
@@ -972,78 +960,6 @@
         address0 = FAILURE;
       } else {
         address0 = new TreeNode8(this._input.substring(index1, this._offset), index1, elements0);
-        this._offset = this._offset;
-      }
-      this._cache._msg_show_entity[index0] = [address0, this._offset];
-      return address0;
-    },
-
-    _read_msg_show: function() {
-      var address0 = FAILURE, index0 = this._offset;
-      this._cache._msg_show = this._cache._msg_show || {};
-      var cached = this._cache._msg_show[index0];
-      if (cached) {
-        this._offset = cached[1];
-        return cached[0];
-      }
-      var index1 = this._offset, elements0 = new Array(4);
-      var address1 = FAILURE;
-      address1 = this._read_speechAct_show();
-      if (address1 !== FAILURE) {
-        elements0[0] = address1;
-        var address2 = FAILURE;
-        address2 = this._read___();
-        if (address2 !== FAILURE) {
-          elements0[1] = address2;
-          var address3 = FAILURE;
-          address3 = this._read_entityType();
-          if (address3 !== FAILURE) {
-            elements0[2] = address3;
-            var address4 = FAILURE;
-            var index2 = this._offset;
-            var chunk0 = null;
-            if (this._offset < this._inputSize) {
-              chunk0 = this._input.substring(this._offset, this._offset + 1);
-            }
-            if (chunk0 !== null && chunk0.toLowerCase() === 's'.toLowerCase()) {
-              address4 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
-              this._offset = this._offset + 1;
-            } else {
-              address4 = FAILURE;
-              if (this._offset > this._failure) {
-                this._failure = this._offset;
-                this._expected = [];
-              }
-              if (this._offset === this._failure) {
-                this._expected.push('`s`');
-              }
-            }
-            if (address4 === FAILURE) {
-              address4 = new TreeNode(this._input.substring(index2, index2), index2);
-              this._offset = index2;
-            }
-            if (address4 !== FAILURE) {
-              elements0[3] = address4;
-            } else {
-              elements0 = null;
-              this._offset = index1;
-            }
-          } else {
-            elements0 = null;
-            this._offset = index1;
-          }
-        } else {
-          elements0 = null;
-          this._offset = index1;
-        }
-      } else {
-        elements0 = null;
-        this._offset = index1;
-      }
-      if (elements0 === null) {
-        address0 = FAILURE;
-      } else {
-        address0 = new TreeNode9(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_show[index0] = [address0, this._offset];
@@ -1280,7 +1196,7 @@
         this._offset = cached[1];
         return cached[0];
       }
-      var remaining0 = 0, index1 = this._offset, elements0 = [], address1 = true;
+      var remaining0 = 1, index1 = this._offset, elements0 = [], address1 = true;
       while (address1 !== FAILURE) {
         var index2 = this._offset, elements1 = new Array(2);
         var address2 = FAILURE;

--- a/src/protocols/entityChat.js
+++ b/src/protocols/entityChat.js
@@ -54,14 +54,16 @@
   var TreeNode1 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
     this['speechAct_create'] = elements[0];
-    this['__'] = elements[1];
+    this['__'] = elements[5];
     this['entityType'] = elements[2];
+    this['entityId'] = elements[4];
+    this['entityText'] = elements[6];
   };
   inherit(TreeNode1, TreeNode);
 
   var TreeNode2 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_create'] = elements[0];
+    this['speechAct_update'] = elements[0];
     this['__'] = elements[3];
     this['entityType'] = elements[2];
     this['entityId'] = elements[4];
@@ -70,57 +72,38 @@
 
   var TreeNode3 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_create'] = elements[0];
-    this['__'] = elements[5];
-    this['entityType'] = elements[2];
-    this['entityId'] = elements[4];
-    this['entityText'] = elements[6];
-  };
-  inherit(TreeNode3, TreeNode);
-
-  var TreeNode4 = function(text, offset, elements) {
-    TreeNode.apply(this, arguments);
-    this['speechAct_update'] = elements[0];
-    this['__'] = elements[3];
-    this['entityType'] = elements[2];
-    this['entityId'] = elements[4];
-  };
-  inherit(TreeNode4, TreeNode);
-
-  var TreeNode5 = function(text, offset, elements) {
-    TreeNode.apply(this, arguments);
     this['speechAct_join'] = elements[0];
     this['__'] = elements[3];
     this['entityType_join'] = elements[2];
     this['entityId'] = elements[4];
   };
-  inherit(TreeNode5, TreeNode);
+  inherit(TreeNode3, TreeNode);
 
-  var TreeNode6 = function(text, offset, elements) {
+  var TreeNode4 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
     this['speechAct_invite'] = elements[0];
     this['__'] = elements[3];
     this['entityType_invite'] = elements[2];
     this['entityId'] = elements[4];
   };
-  inherit(TreeNode6, TreeNode);
+  inherit(TreeNode4, TreeNode);
 
-  var TreeNode7 = function(text, offset, elements) {
+  var TreeNode5 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
     this['speechAct_list'] = elements[0];
     this['__'] = elements[1];
     this['entityType'] = elements[2];
   };
-  inherit(TreeNode7, TreeNode);
+  inherit(TreeNode5, TreeNode);
 
-  var TreeNode8 = function(text, offset, elements) {
+  var TreeNode6 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
     this['speechAct_show'] = elements[0];
     this['__'] = elements[3];
     this['entityType'] = elements[2];
     this['entityId'] = elements[4];
   };
-  inherit(TreeNode8, TreeNode);
+  inherit(TreeNode6, TreeNode);
 
   var FAILURE = {};
 
@@ -134,32 +117,24 @@
         return cached[0];
       }
       var index1 = this._offset;
-      address0 = this._read_msg_create_full();
+      address0 = this._read_msg_create();
       if (address0 === FAILURE) {
         this._offset = index1;
-        address0 = this._read_msg_create_with_id();
+        address0 = this._read_msg_update();
         if (address0 === FAILURE) {
           this._offset = index1;
-          address0 = this._read_msg_create();
+          address0 = this._read_msg_join();
           if (address0 === FAILURE) {
             this._offset = index1;
-            address0 = this._read_msg_update();
+            address0 = this._read_msg_invite();
             if (address0 === FAILURE) {
               this._offset = index1;
-              address0 = this._read_msg_join();
+              address0 = this._read_msg_list();
               if (address0 === FAILURE) {
                 this._offset = index1;
-                address0 = this._read_msg_invite();
+                address0 = this._read_msg_show();
                 if (address0 === FAILURE) {
                   this._offset = index1;
-                  address0 = this._read_msg_list();
-                  if (address0 === FAILURE) {
-                    this._offset = index1;
-                    address0 = this._read_msg_show();
-                    if (address0 === FAILURE) {
-                      this._offset = index1;
-                    }
-                  }
                 }
               }
             }
@@ -174,108 +149,6 @@
       var address0 = FAILURE, index0 = this._offset;
       this._cache._msg_create = this._cache._msg_create || {};
       var cached = this._cache._msg_create[index0];
-      if (cached) {
-        this._offset = cached[1];
-        return cached[0];
-      }
-      var index1 = this._offset, elements0 = new Array(3);
-      var address1 = FAILURE;
-      address1 = this._read_speechAct_create();
-      if (address1 !== FAILURE) {
-        elements0[0] = address1;
-        var address2 = FAILURE;
-        address2 = this._read___();
-        if (address2 !== FAILURE) {
-          elements0[1] = address2;
-          var address3 = FAILURE;
-          address3 = this._read_entityType();
-          if (address3 !== FAILURE) {
-            elements0[2] = address3;
-          } else {
-            elements0 = null;
-            this._offset = index1;
-          }
-        } else {
-          elements0 = null;
-          this._offset = index1;
-        }
-      } else {
-        elements0 = null;
-        this._offset = index1;
-      }
-      if (elements0 === null) {
-        address0 = FAILURE;
-      } else {
-        address0 = new TreeNode1(this._input.substring(index1, this._offset), index1, elements0);
-        this._offset = this._offset;
-      }
-      this._cache._msg_create[index0] = [address0, this._offset];
-      return address0;
-    },
-
-    _read_msg_create_with_id: function() {
-      var address0 = FAILURE, index0 = this._offset;
-      this._cache._msg_create_with_id = this._cache._msg_create_with_id || {};
-      var cached = this._cache._msg_create_with_id[index0];
-      if (cached) {
-        this._offset = cached[1];
-        return cached[0];
-      }
-      var index1 = this._offset, elements0 = new Array(5);
-      var address1 = FAILURE;
-      address1 = this._read_speechAct_create();
-      if (address1 !== FAILURE) {
-        elements0[0] = address1;
-        var address2 = FAILURE;
-        address2 = this._read___();
-        if (address2 !== FAILURE) {
-          elements0[1] = address2;
-          var address3 = FAILURE;
-          address3 = this._read_entityType();
-          if (address3 !== FAILURE) {
-            elements0[2] = address3;
-            var address4 = FAILURE;
-            address4 = this._read___();
-            if (address4 !== FAILURE) {
-              elements0[3] = address4;
-              var address5 = FAILURE;
-              address5 = this._read_entityId();
-              if (address5 !== FAILURE) {
-                elements0[4] = address5;
-              } else {
-                elements0 = null;
-                this._offset = index1;
-              }
-            } else {
-              elements0 = null;
-              this._offset = index1;
-            }
-          } else {
-            elements0 = null;
-            this._offset = index1;
-          }
-        } else {
-          elements0 = null;
-          this._offset = index1;
-        }
-      } else {
-        elements0 = null;
-        this._offset = index1;
-      }
-      if (elements0 === null) {
-        address0 = FAILURE;
-      } else {
-        address0 = new TreeNode2(this._input.substring(index1, this._offset), index1, elements0);
-        this._offset = this._offset;
-      }
-      this._cache._msg_create_with_id[index0] = [address0, this._offset];
-      return address0;
-    },
-
-    _read_msg_create_full: function() {
-      var address0 = FAILURE, index0 = this._offset;
-      this._cache._msg_create_full = this._cache._msg_create_full || {};
-      var cached = this._cache._msg_create_full[index0];
       if (cached) {
         this._offset = cached[1];
         return cached[0];
@@ -340,10 +213,10 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode3(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode1(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
-      this._cache._msg_create_full[index0] = [address0, this._offset];
+      this._cache._msg_create[index0] = [address0, this._offset];
       return address0;
     },
 
@@ -472,7 +345,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode4(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode2(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_update[index0] = [address0, this._offset];
@@ -624,7 +497,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode5(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode3(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_join[index0] = [address0, this._offset];
@@ -741,7 +614,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode6(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode4(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_invite[index0] = [address0, this._offset];
@@ -871,7 +744,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode7(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode5(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_list[index0] = [address0, this._offset];
@@ -959,7 +832,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode8(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode6(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_show[index0] = [address0, this._offset];

--- a/src/protocols/entityChat.js
+++ b/src/protocols/entityChat.js
@@ -1,0 +1,792 @@
+(function() {
+  'use strict';
+
+  var extend = function (destination, source) {
+    if (!destination || !source) return destination;
+    for (var key in source) {
+      if (destination[key] !== source[key])
+        destination[key] = source[key];
+    }
+    return destination;
+  };
+
+  var formatError = function (input, offset, expected) {
+    var lines = input.split(/\n/g),
+        lineNo = 0,
+        position = 0;
+
+    while (position <= offset) {
+      position += lines[lineNo].length + 1;
+      lineNo += 1;
+    }
+    var message = 'Line ' + lineNo + ': expected ' + expected.join(', ') + '\n',
+        line = lines[lineNo - 1];
+
+    message += line + '\n';
+    position -= line.length + 1;
+
+    while (position < offset) {
+      message += ' ';
+      position += 1;
+    }
+    return message + '^';
+  };
+
+  var inherit = function (subclass, parent) {
+    var chain = function() {};
+    chain.prototype = parent.prototype;
+    subclass.prototype = new chain();
+    subclass.prototype.constructor = subclass;
+  };
+
+  var TreeNode = function(text, offset, elements) {
+    this.text = text;
+    this.offset = offset;
+    this.elements = elements || [];
+  };
+
+  TreeNode.prototype.forEach = function(block, context) {
+    for (var el = this.elements, i = 0, n = el.length; i < n; i++) {
+      block.call(context, el[i], i, el);
+    }
+  };
+
+  var TreeNode1 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct'] = elements[0];
+    this['__'] = elements[3];
+    this['entityType'] = elements[2];
+    this['entityId'] = elements[4];
+  };
+  inherit(TreeNode1, TreeNode);
+
+  var FAILURE = {};
+
+  var Grammar = {
+    _read_message: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._message = this._cache._message || {};
+      var cached = this._cache._message[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(7);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+                var address6 = FAILURE;
+                var index2 = this._offset;
+                address6 = this._read___();
+                if (address6 === FAILURE) {
+                  address6 = new TreeNode(this._input.substring(index2, index2), index2);
+                  this._offset = index2;
+                }
+                if (address6 !== FAILURE) {
+                  elements0[5] = address6;
+                  var address7 = FAILURE;
+                  var index3 = this._offset;
+                  address7 = this._read_text();
+                  if (address7 === FAILURE) {
+                    address7 = new TreeNode(this._input.substring(index3, index3), index3);
+                    this._offset = index3;
+                  }
+                  if (address7 !== FAILURE) {
+                    elements0[6] = address7;
+                  } else {
+                    elements0 = null;
+                    this._offset = index1;
+                  }
+                } else {
+                  elements0 = null;
+                  this._offset = index1;
+                }
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode1(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._message[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct = this._cache._speechAct || {};
+      var cached = this._cache._speechAct[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset;
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 4);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'join'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+        this._offset = this._offset + 4;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`join`');
+        }
+      }
+      if (address0 === FAILURE) {
+        this._offset = index1;
+        var chunk1 = null;
+        if (this._offset < this._inputSize) {
+          chunk1 = this._input.substring(this._offset, this._offset + 6);
+        }
+        if (chunk1 !== null && chunk1.toLowerCase() === 'create'.toLowerCase()) {
+          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+          this._offset = this._offset + 6;
+        } else {
+          address0 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('`create`');
+          }
+        }
+        if (address0 === FAILURE) {
+          this._offset = index1;
+          var chunk2 = null;
+          if (this._offset < this._inputSize) {
+            chunk2 = this._input.substring(this._offset, this._offset + 3);
+          }
+          if (chunk2 !== null && chunk2.toLowerCase() === 'add'.toLowerCase()) {
+            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 3), this._offset);
+            this._offset = this._offset + 3;
+          } else {
+            address0 = FAILURE;
+            if (this._offset > this._failure) {
+              this._failure = this._offset;
+              this._expected = [];
+            }
+            if (this._offset === this._failure) {
+              this._expected.push('`add`');
+            }
+          }
+          if (address0 === FAILURE) {
+            this._offset = index1;
+            var chunk3 = null;
+            if (this._offset < this._inputSize) {
+              chunk3 = this._input.substring(this._offset, this._offset + 6);
+            }
+            if (chunk3 !== null && chunk3.toLowerCase() === 'invite'.toLowerCase()) {
+              address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+              this._offset = this._offset + 6;
+            } else {
+              address0 = FAILURE;
+              if (this._offset > this._failure) {
+                this._failure = this._offset;
+                this._expected = [];
+              }
+              if (this._offset === this._failure) {
+                this._expected.push('`invite`');
+              }
+            }
+            if (address0 === FAILURE) {
+              this._offset = index1;
+              var chunk4 = null;
+              if (this._offset < this._inputSize) {
+                chunk4 = this._input.substring(this._offset, this._offset + 4);
+              }
+              if (chunk4 !== null && chunk4.toLowerCase() === 'show'.toLowerCase()) {
+                address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+                this._offset = this._offset + 4;
+              } else {
+                address0 = FAILURE;
+                if (this._offset > this._failure) {
+                  this._failure = this._offset;
+                  this._expected = [];
+                }
+                if (this._offset === this._failure) {
+                  this._expected.push('`show`');
+                }
+              }
+              if (address0 === FAILURE) {
+                this._offset = index1;
+                var chunk5 = null;
+                if (this._offset < this._inputSize) {
+                  chunk5 = this._input.substring(this._offset, this._offset + 4);
+                }
+                if (chunk5 !== null && chunk5.toLowerCase() === 'list'.toLowerCase()) {
+                  address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+                  this._offset = this._offset + 4;
+                } else {
+                  address0 = FAILURE;
+                  if (this._offset > this._failure) {
+                    this._failure = this._offset;
+                    this._expected = [];
+                  }
+                  if (this._offset === this._failure) {
+                    this._expected.push('`list`');
+                  }
+                }
+                if (address0 === FAILURE) {
+                  this._offset = index1;
+                  var chunk6 = null;
+                  if (this._offset < this._inputSize) {
+                    chunk6 = this._input.substring(this._offset, this._offset + 6);
+                  }
+                  if (chunk6 !== null && chunk6.toLowerCase() === 'delete'.toLowerCase()) {
+                    address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+                    this._offset = this._offset + 6;
+                  } else {
+                    address0 = FAILURE;
+                    if (this._offset > this._failure) {
+                      this._failure = this._offset;
+                      this._expected = [];
+                    }
+                    if (this._offset === this._failure) {
+                      this._expected.push('`delete`');
+                    }
+                  }
+                  if (address0 === FAILURE) {
+                    this._offset = index1;
+                    var chunk7 = null;
+                    if (this._offset < this._inputSize) {
+                      chunk7 = this._input.substring(this._offset, this._offset + 7);
+                    }
+                    if (chunk7 !== null && chunk7.toLowerCase() === 'decline'.toLowerCase()) {
+                      address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+                      this._offset = this._offset + 7;
+                    } else {
+                      address0 = FAILURE;
+                      if (this._offset > this._failure) {
+                        this._failure = this._offset;
+                        this._expected = [];
+                      }
+                      if (this._offset === this._failure) {
+                        this._expected.push('`decline`');
+                      }
+                    }
+                    if (address0 === FAILURE) {
+                      this._offset = index1;
+                      var chunk8 = null;
+                      if (this._offset < this._inputSize) {
+                        chunk8 = this._input.substring(this._offset, this._offset + 7);
+                      }
+                      if (chunk8 !== null && chunk8.toLowerCase() === 'approve'.toLowerCase()) {
+                        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+                        this._offset = this._offset + 7;
+                      } else {
+                        address0 = FAILURE;
+                        if (this._offset > this._failure) {
+                          this._failure = this._offset;
+                          this._expected = [];
+                        }
+                        if (this._offset === this._failure) {
+                          this._expected.push('`approve`');
+                        }
+                      }
+                      if (address0 === FAILURE) {
+                        this._offset = index1;
+                        var chunk9 = null;
+                        if (this._offset < this._inputSize) {
+                          chunk9 = this._input.substring(this._offset, this._offset + 7);
+                        }
+                        if (chunk9 !== null && chunk9.toLowerCase() === 'discuss'.toLowerCase()) {
+                          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+                          this._offset = this._offset + 7;
+                        } else {
+                          address0 = FAILURE;
+                          if (this._offset > this._failure) {
+                            this._failure = this._offset;
+                            this._expected = [];
+                          }
+                          if (this._offset === this._failure) {
+                            this._expected.push('`discuss`');
+                          }
+                        }
+                        if (address0 === FAILURE) {
+                          this._offset = index1;
+                          var chunk10 = null;
+                          if (this._offset < this._inputSize) {
+                            chunk10 = this._input.substring(this._offset, this._offset + 7);
+                          }
+                          if (chunk10 !== null && chunk10.toLowerCase() === 'suggest'.toLowerCase()) {
+                            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+                            this._offset = this._offset + 7;
+                          } else {
+                            address0 = FAILURE;
+                            if (this._offset > this._failure) {
+                              this._failure = this._offset;
+                              this._expected = [];
+                            }
+                            if (this._offset === this._failure) {
+                              this._expected.push('`suggest`');
+                            }
+                          }
+                          if (address0 === FAILURE) {
+                            this._offset = index1;
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      this._cache._speechAct[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_entityType: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._entityType = this._cache._entityType || {};
+      var cached = this._cache._entityType[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset;
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 7);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'purpose'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+        this._offset = this._offset + 7;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`purpose`');
+        }
+      }
+      if (address0 === FAILURE) {
+        this._offset = index1;
+        var chunk1 = null;
+        if (this._offset < this._inputSize) {
+          chunk1 = this._input.substring(this._offset, this._offset + 4);
+        }
+        if (chunk1 !== null && chunk1.toLowerCase() === 'logo'.toLowerCase()) {
+          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+          this._offset = this._offset + 4;
+        } else {
+          address0 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('`logo`');
+          }
+        }
+        if (address0 === FAILURE) {
+          this._offset = index1;
+          var chunk2 = null;
+          if (this._offset < this._inputSize) {
+            chunk2 = this._input.substring(this._offset, this._offset + 4);
+          }
+          if (chunk2 !== null && chunk2.toLowerCase() === 'name'.toLowerCase()) {
+            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+            this._offset = this._offset + 4;
+          } else {
+            address0 = FAILURE;
+            if (this._offset > this._failure) {
+              this._failure = this._offset;
+              this._expected = [];
+            }
+            if (this._offset === this._failure) {
+              this._expected.push('`name`');
+            }
+          }
+          if (address0 === FAILURE) {
+            this._offset = index1;
+            var chunk3 = null;
+            if (this._offset < this._inputSize) {
+              chunk3 = this._input.substring(this._offset, this._offset + 11);
+            }
+            if (chunk3 !== null && chunk3.toLowerCase() === 'description'.toLowerCase()) {
+              address0 = new TreeNode(this._input.substring(this._offset, this._offset + 11), this._offset);
+              this._offset = this._offset + 11;
+            } else {
+              address0 = FAILURE;
+              if (this._offset > this._failure) {
+                this._failure = this._offset;
+                this._expected = [];
+              }
+              if (this._offset === this._failure) {
+                this._expected.push('`description`');
+              }
+            }
+            if (address0 === FAILURE) {
+              this._offset = index1;
+              var chunk4 = null;
+              if (this._offset < this._inputSize) {
+                chunk4 = this._input.substring(this._offset, this._offset + 5);
+              }
+              if (chunk4 !== null && chunk4.toLowerCase() === 'intro'.toLowerCase()) {
+                address0 = new TreeNode(this._input.substring(this._offset, this._offset + 5), this._offset);
+                this._offset = this._offset + 5;
+              } else {
+                address0 = FAILURE;
+                if (this._offset > this._failure) {
+                  this._failure = this._offset;
+                  this._expected = [];
+                }
+                if (this._offset === this._failure) {
+                  this._expected.push('`intro`');
+                }
+              }
+              if (address0 === FAILURE) {
+                this._offset = index1;
+                var chunk5 = null;
+                if (this._offset < this._inputSize) {
+                  chunk5 = this._input.substring(this._offset, this._offset + 3);
+                }
+                if (chunk5 !== null && chunk5.toLowerCase() === 'tag'.toLowerCase()) {
+                  address0 = new TreeNode(this._input.substring(this._offset, this._offset + 3), this._offset);
+                  this._offset = this._offset + 3;
+                } else {
+                  address0 = FAILURE;
+                  if (this._offset > this._failure) {
+                    this._failure = this._offset;
+                    this._expected = [];
+                  }
+                  if (this._offset === this._failure) {
+                    this._expected.push('`tag`');
+                  }
+                }
+                if (address0 === FAILURE) {
+                  this._offset = index1;
+                  var chunk6 = null;
+                  if (this._offset < this._inputSize) {
+                    chunk6 = this._input.substring(this._offset, this._offset + 4);
+                  }
+                  if (chunk6 !== null && chunk6.toLowerCase() === 'tool'.toLowerCase()) {
+                    address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+                    this._offset = this._offset + 4;
+                  } else {
+                    address0 = FAILURE;
+                    if (this._offset > this._failure) {
+                      this._failure = this._offset;
+                      this._expected = [];
+                    }
+                    if (this._offset === this._failure) {
+                      this._expected.push('`tool`');
+                    }
+                  }
+                  if (address0 === FAILURE) {
+                    this._offset = index1;
+                    var chunk7 = null;
+                    if (this._offset < this._inputSize) {
+                      chunk7 = this._input.substring(this._offset, this._offset + 6);
+                    }
+                    if (chunk7 !== null && chunk7.toLowerCase() === 'member'.toLowerCase()) {
+                      address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+                      this._offset = this._offset + 6;
+                    } else {
+                      address0 = FAILURE;
+                      if (this._offset > this._failure) {
+                        this._failure = this._offset;
+                        this._expected = [];
+                      }
+                      if (this._offset === this._failure) {
+                        this._expected.push('`member`');
+                      }
+                    }
+                    if (address0 === FAILURE) {
+                      this._offset = index1;
+                      var chunk8 = null;
+                      if (this._offset < this._inputSize) {
+                        chunk8 = this._input.substring(this._offset, this._offset + 4);
+                      }
+                      if (chunk8 !== null && chunk8.toLowerCase() === 'team'.toLowerCase()) {
+                        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+                        this._offset = this._offset + 4;
+                      } else {
+                        address0 = FAILURE;
+                        if (this._offset > this._failure) {
+                          this._failure = this._offset;
+                          this._expected = [];
+                        }
+                        if (this._offset === this._failure) {
+                          this._expected.push('`team`');
+                        }
+                      }
+                      if (address0 === FAILURE) {
+                        this._offset = index1;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      this._cache._entityType[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_entityId: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._entityId = this._cache._entityId || {};
+      var cached = this._cache._entityId[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var remaining0 = 0, index1 = this._offset, elements0 = [], address1 = true;
+      while (address1 !== FAILURE) {
+        var index2 = this._offset, elements1 = new Array(2);
+        var address2 = FAILURE;
+        var index3 = this._offset;
+        var chunk0 = null;
+        if (this._offset < this._inputSize) {
+          chunk0 = this._input.substring(this._offset, this._offset + 1);
+        }
+        if (chunk0 === ' ') {
+          address2 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+          this._offset = this._offset + 1;
+        } else {
+          address2 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('" "');
+          }
+        }
+        this._offset = index3;
+        if (address2 === FAILURE) {
+          address2 = new TreeNode(this._input.substring(this._offset, this._offset), this._offset);
+          this._offset = this._offset;
+        } else {
+          address2 = FAILURE;
+        }
+        if (address2 !== FAILURE) {
+          elements1[0] = address2;
+          var address3 = FAILURE;
+          if (this._offset < this._inputSize) {
+            address3 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+            this._offset = this._offset + 1;
+          } else {
+            address3 = FAILURE;
+            if (this._offset > this._failure) {
+              this._failure = this._offset;
+              this._expected = [];
+            }
+            if (this._offset === this._failure) {
+              this._expected.push('<any char>');
+            }
+          }
+          if (address3 !== FAILURE) {
+            elements1[1] = address3;
+          } else {
+            elements1 = null;
+            this._offset = index2;
+          }
+        } else {
+          elements1 = null;
+          this._offset = index2;
+        }
+        if (elements1 === null) {
+          address1 = FAILURE;
+        } else {
+          address1 = new TreeNode(this._input.substring(index2, this._offset), index2, elements1);
+          this._offset = this._offset;
+        }
+        if (address1 !== FAILURE) {
+          elements0.push(address1);
+          --remaining0;
+        }
+      }
+      if (remaining0 <= 0) {
+        address0 = new TreeNode(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      } else {
+        address0 = FAILURE;
+      }
+      this._cache._entityId[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_text: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._text = this._cache._text || {};
+      var cached = this._cache._text[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      if (this._offset < this._inputSize) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+        this._offset = this._offset + 1;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('<any char>');
+        }
+      }
+      this._cache._text[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read___: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache.___ = this._cache.___ || {};
+      var cached = this._cache.___[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var remaining0 = 0, index1 = this._offset, elements0 = [], address1 = true;
+      while (address1 !== FAILURE) {
+        var index2 = this._offset;
+        var chunk0 = null;
+        if (this._offset < this._inputSize) {
+          chunk0 = this._input.substring(this._offset, this._offset + 1);
+        }
+        if (chunk0 === ' ') {
+          address1 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+          this._offset = this._offset + 1;
+        } else {
+          address1 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('" "');
+          }
+        }
+        if (address1 === FAILURE) {
+          this._offset = index2;
+          var chunk1 = null;
+          if (this._offset < this._inputSize) {
+            chunk1 = this._input.substring(this._offset, this._offset + 1);
+          }
+          if (chunk1 !== null && /^[\n\r\t]/.test(chunk1)) {
+            address1 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+            this._offset = this._offset + 1;
+          } else {
+            address1 = FAILURE;
+            if (this._offset > this._failure) {
+              this._failure = this._offset;
+              this._expected = [];
+            }
+            if (this._offset === this._failure) {
+              this._expected.push('[\\n\\r\\t]');
+            }
+          }
+          if (address1 === FAILURE) {
+            this._offset = index2;
+          }
+        }
+        if (address1 !== FAILURE) {
+          elements0.push(address1);
+          --remaining0;
+        }
+      }
+      if (remaining0 <= 0) {
+        address0 = new TreeNode(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      } else {
+        address0 = FAILURE;
+      }
+      this._cache.___[index0] = [address0, this._offset];
+      return address0;
+    }
+  };
+
+  var Parser = function(input, actions, types) {
+    this._input = input;
+    this._inputSize = input.length;
+    this._actions = actions;
+    this._types = types;
+    this._offset = 0;
+    this._cache = {};
+    this._failure = 0;
+    this._expected = [];
+  };
+
+  Parser.prototype.parse = function() {
+    var tree = this._read_message();
+    if (tree !== FAILURE && this._offset === this._inputSize) {
+      return tree;
+    }
+    if (this._expected.length === 0) {
+      this._failure = this._offset;
+      this._expected.push('<EOF>');
+    }
+    this.constructor.lastError = {offset: this._offset, expected: this._expected};
+    throw new SyntaxError(formatError(this._input, this._failure, this._expected));
+  };
+
+  var parse = function(input, options) {
+    options = options || {};
+    var parser = new Parser(input, options.actions, options.types);
+    return parser.parse();
+  };
+  extend(Parser.prototype, Grammar);
+
+  var exported = {Grammar: Grammar, Parser: Parser, parse: parse};
+
+  if (typeof require === 'function' && typeof exports === 'object') {
+    extend(exports, exported);
+  } else {
+    var namespace = typeof this !== 'undefined' ? this : window;
+    namespace.EntityChat = exported;
+  }
+})();

--- a/src/protocols/entityChat.js
+++ b/src/protocols/entityChat.js
@@ -53,12 +53,82 @@
 
   var TreeNode1 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct'] = elements[0];
+    this['speechAct_create'] = elements[0];
+    this['__'] = elements[1];
+    this['entityType'] = elements[2];
+  };
+  inherit(TreeNode1, TreeNode);
+
+  var TreeNode2 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_create'] = elements[0];
     this['__'] = elements[3];
     this['entityType'] = elements[2];
     this['entityId'] = elements[4];
   };
-  inherit(TreeNode1, TreeNode);
+  inherit(TreeNode2, TreeNode);
+
+  var TreeNode3 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_create'] = elements[0];
+    this['__'] = elements[5];
+    this['entityType'] = elements[2];
+    this['entityId'] = elements[4];
+    this['entityText'] = elements[6];
+  };
+  inherit(TreeNode3, TreeNode);
+
+  var TreeNode4 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_update'] = elements[0];
+    this['__'] = elements[3];
+    this['entityType'] = elements[2];
+    this['entityId'] = elements[4];
+  };
+  inherit(TreeNode4, TreeNode);
+
+  var TreeNode5 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_join'] = elements[0];
+    this['__'] = elements[3];
+    this['entityType_join'] = elements[2];
+    this['entityId'] = elements[4];
+  };
+  inherit(TreeNode5, TreeNode);
+
+  var TreeNode6 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_invite'] = elements[0];
+    this['__'] = elements[3];
+    this['entityType_invite'] = elements[2];
+    this['entityId'] = elements[4];
+  };
+  inherit(TreeNode6, TreeNode);
+
+  var TreeNode7 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_list'] = elements[0];
+    this['__'] = elements[1];
+    this['entityType'] = elements[2];
+  };
+  inherit(TreeNode7, TreeNode);
+
+  var TreeNode8 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_show'] = elements[0];
+    this['__'] = elements[3];
+    this['entityType'] = elements[2];
+    this['entityId'] = elements[4];
+  };
+  inherit(TreeNode8, TreeNode);
+
+  var TreeNode9 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_show'] = elements[0];
+    this['__'] = elements[1];
+    this['entityType'] = elements[2];
+  };
+  inherit(TreeNode9, TreeNode);
 
   var FAILURE = {};
 
@@ -71,9 +141,160 @@
         this._offset = cached[1];
         return cached[0];
       }
+      var index1 = this._offset;
+      address0 = this._read_msg_create_full();
+      if (address0 === FAILURE) {
+        this._offset = index1;
+        address0 = this._read_msg_create_with_id();
+        if (address0 === FAILURE) {
+          this._offset = index1;
+          address0 = this._read_msg_create();
+          if (address0 === FAILURE) {
+            this._offset = index1;
+            address0 = this._read_msg_update();
+            if (address0 === FAILURE) {
+              this._offset = index1;
+              address0 = this._read_msg_join();
+              if (address0 === FAILURE) {
+                this._offset = index1;
+                address0 = this._read_msg_invite();
+                if (address0 === FAILURE) {
+                  this._offset = index1;
+                  address0 = this._read_msg_list();
+                  if (address0 === FAILURE) {
+                    this._offset = index1;
+                    address0 = this._read_msg_show_entity();
+                    if (address0 === FAILURE) {
+                      this._offset = index1;
+                      address0 = this._read_msg_show();
+                      if (address0 === FAILURE) {
+                        this._offset = index1;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      this._cache._message[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_create: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_create = this._cache._msg_create || {};
+      var cached = this._cache._msg_create[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(3);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_create();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode1(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_create[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_create_with_id: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_create_with_id = this._cache._msg_create_with_id || {};
+      var cached = this._cache._msg_create_with_id[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(5);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_create();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode2(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_create_with_id[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_create_full: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_create_full = this._cache._msg_create_full || {};
+      var cached = this._cache._msg_create_full[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
       var index1 = this._offset, elements0 = new Array(7);
       var address1 = FAILURE;
-      address1 = this._read_speechAct();
+      address1 = this._read_speechAct_create();
       if (address1 !== FAILURE) {
         elements0[0] = address1;
         var address2 = FAILURE;
@@ -93,21 +314,11 @@
               if (address5 !== FAILURE) {
                 elements0[4] = address5;
                 var address6 = FAILURE;
-                var index2 = this._offset;
                 address6 = this._read___();
-                if (address6 === FAILURE) {
-                  address6 = new TreeNode(this._input.substring(index2, index2), index2);
-                  this._offset = index2;
-                }
                 if (address6 !== FAILURE) {
                   elements0[5] = address6;
                   var address7 = FAILURE;
-                  var index3 = this._offset;
-                  address7 = this._read_text();
-                  if (address7 === FAILURE) {
-                    address7 = new TreeNode(this._input.substring(index3, index3), index3);
-                    this._offset = index3;
-                  }
+                  address7 = this._read_entityText();
                   if (address7 !== FAILURE) {
                     elements0[6] = address7;
                   } else {
@@ -141,22 +352,305 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode1(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode3(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
-      this._cache._message[index0] = [address0, this._offset];
+      this._cache._msg_create_full[index0] = [address0, this._offset];
       return address0;
     },
 
-    _read_speechAct: function() {
+    _read_speechAct_create: function() {
       var address0 = FAILURE, index0 = this._offset;
-      this._cache._speechAct = this._cache._speechAct || {};
-      var cached = this._cache._speechAct[index0];
+      this._cache._speechAct_create = this._cache._speechAct_create || {};
+      var cached = this._cache._speechAct_create[index0];
       if (cached) {
         this._offset = cached[1];
         return cached[0];
       }
       var index1 = this._offset;
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 6);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'create'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+        this._offset = this._offset + 6;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`create`');
+        }
+      }
+      if (address0 === FAILURE) {
+        this._offset = index1;
+        var chunk1 = null;
+        if (this._offset < this._inputSize) {
+          chunk1 = this._input.substring(this._offset, this._offset + 3);
+        }
+        if (chunk1 !== null && chunk1.toLowerCase() === 'add'.toLowerCase()) {
+          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 3), this._offset);
+          this._offset = this._offset + 3;
+        } else {
+          address0 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('`add`');
+          }
+        }
+        if (address0 === FAILURE) {
+          this._offset = index1;
+          var chunk2 = null;
+          if (this._offset < this._inputSize) {
+            chunk2 = this._input.substring(this._offset, this._offset + 7);
+          }
+          if (chunk2 !== null && chunk2.toLowerCase() === 'suggest'.toLowerCase()) {
+            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+            this._offset = this._offset + 7;
+          } else {
+            address0 = FAILURE;
+            if (this._offset > this._failure) {
+              this._failure = this._offset;
+              this._expected = [];
+            }
+            if (this._offset === this._failure) {
+              this._expected.push('`suggest`');
+            }
+          }
+          if (address0 === FAILURE) {
+            this._offset = index1;
+          }
+        }
+      }
+      this._cache._speechAct_create[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_update: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_update = this._cache._msg_update || {};
+      var cached = this._cache._msg_update[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(5);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_update();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode4(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_update[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct_update: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct_update = this._cache._speechAct_update || {};
+      var cached = this._cache._speechAct_update[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset;
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 7);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'decline'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+        this._offset = this._offset + 7;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`decline`');
+        }
+      }
+      if (address0 === FAILURE) {
+        this._offset = index1;
+        var chunk1 = null;
+        if (this._offset < this._inputSize) {
+          chunk1 = this._input.substring(this._offset, this._offset + 7);
+        }
+        if (chunk1 !== null && chunk1.toLowerCase() === 'approve'.toLowerCase()) {
+          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+          this._offset = this._offset + 7;
+        } else {
+          address0 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('`approve`');
+          }
+        }
+        if (address0 === FAILURE) {
+          this._offset = index1;
+          var chunk2 = null;
+          if (this._offset < this._inputSize) {
+            chunk2 = this._input.substring(this._offset, this._offset + 7);
+          }
+          if (chunk2 !== null && chunk2.toLowerCase() === 'discuss'.toLowerCase()) {
+            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+            this._offset = this._offset + 7;
+          } else {
+            address0 = FAILURE;
+            if (this._offset > this._failure) {
+              this._failure = this._offset;
+              this._expected = [];
+            }
+            if (this._offset === this._failure) {
+              this._expected.push('`discuss`');
+            }
+          }
+          if (address0 === FAILURE) {
+            this._offset = index1;
+            var chunk3 = null;
+            if (this._offset < this._inputSize) {
+              chunk3 = this._input.substring(this._offset, this._offset + 6);
+            }
+            if (chunk3 !== null && chunk3.toLowerCase() === 'delete'.toLowerCase()) {
+              address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+              this._offset = this._offset + 6;
+            } else {
+              address0 = FAILURE;
+              if (this._offset > this._failure) {
+                this._failure = this._offset;
+                this._expected = [];
+              }
+              if (this._offset === this._failure) {
+                this._expected.push('`delete`');
+              }
+            }
+            if (address0 === FAILURE) {
+              this._offset = index1;
+            }
+          }
+        }
+      }
+      this._cache._speechAct_update[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_join: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_join = this._cache._msg_join || {};
+      var cached = this._cache._msg_join[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(5);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_join();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType_join();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode5(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_join[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct_join: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct_join = this._cache._speechAct_join || {};
+      var cached = this._cache._speechAct_join[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
       var chunk0 = null;
       if (this._offset < this._inputSize) {
         chunk0 = this._input.substring(this._offset, this._offset + 4);
@@ -174,210 +668,414 @@
           this._expected.push('`join`');
         }
       }
-      if (address0 === FAILURE) {
-        this._offset = index1;
-        var chunk1 = null;
-        if (this._offset < this._inputSize) {
-          chunk1 = this._input.substring(this._offset, this._offset + 6);
+      this._cache._speechAct_join[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_entityType_join: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._entityType_join = this._cache._entityType_join || {};
+      var cached = this._cache._entityType_join[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 4);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'team'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+        this._offset = this._offset + 4;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
         }
-        if (chunk1 !== null && chunk1.toLowerCase() === 'create'.toLowerCase()) {
-          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
-          this._offset = this._offset + 6;
-        } else {
-          address0 = FAILURE;
-          if (this._offset > this._failure) {
-            this._failure = this._offset;
-            this._expected = [];
-          }
-          if (this._offset === this._failure) {
-            this._expected.push('`create`');
-          }
+        if (this._offset === this._failure) {
+          this._expected.push('`team`');
         }
-        if (address0 === FAILURE) {
-          this._offset = index1;
-          var chunk2 = null;
-          if (this._offset < this._inputSize) {
-            chunk2 = this._input.substring(this._offset, this._offset + 3);
-          }
-          if (chunk2 !== null && chunk2.toLowerCase() === 'add'.toLowerCase()) {
-            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 3), this._offset);
-            this._offset = this._offset + 3;
-          } else {
-            address0 = FAILURE;
-            if (this._offset > this._failure) {
-              this._failure = this._offset;
-              this._expected = [];
-            }
-            if (this._offset === this._failure) {
-              this._expected.push('`add`');
-            }
-          }
-          if (address0 === FAILURE) {
-            this._offset = index1;
-            var chunk3 = null;
-            if (this._offset < this._inputSize) {
-              chunk3 = this._input.substring(this._offset, this._offset + 6);
-            }
-            if (chunk3 !== null && chunk3.toLowerCase() === 'invite'.toLowerCase()) {
-              address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
-              this._offset = this._offset + 6;
+      }
+      this._cache._entityType_join[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_invite: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_invite = this._cache._msg_invite || {};
+      var cached = this._cache._msg_invite[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(5);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_invite();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType_invite();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
             } else {
-              address0 = FAILURE;
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode6(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_invite[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct_invite: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct_invite = this._cache._speechAct_invite || {};
+      var cached = this._cache._speechAct_invite[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 6);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'invite'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+        this._offset = this._offset + 6;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`invite`');
+        }
+      }
+      this._cache._speechAct_invite[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_entityType_invite: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._entityType_invite = this._cache._entityType_invite || {};
+      var cached = this._cache._entityType_invite[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 6);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'member'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+        this._offset = this._offset + 6;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`member`');
+        }
+      }
+      this._cache._entityType_invite[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_list: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_list = this._cache._msg_list || {};
+      var cached = this._cache._msg_list[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(4);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_list();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            var index2 = this._offset;
+            var chunk0 = null;
+            if (this._offset < this._inputSize) {
+              chunk0 = this._input.substring(this._offset, this._offset + 1);
+            }
+            if (chunk0 !== null && chunk0.toLowerCase() === 's'.toLowerCase()) {
+              address4 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+              this._offset = this._offset + 1;
+            } else {
+              address4 = FAILURE;
               if (this._offset > this._failure) {
                 this._failure = this._offset;
                 this._expected = [];
               }
               if (this._offset === this._failure) {
-                this._expected.push('`invite`');
+                this._expected.push('`s`');
               }
             }
-            if (address0 === FAILURE) {
+            if (address4 === FAILURE) {
+              address4 = new TreeNode(this._input.substring(index2, index2), index2);
+              this._offset = index2;
+            }
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+            } else {
+              elements0 = null;
               this._offset = index1;
-              var chunk4 = null;
-              if (this._offset < this._inputSize) {
-                chunk4 = this._input.substring(this._offset, this._offset + 4);
-              }
-              if (chunk4 !== null && chunk4.toLowerCase() === 'show'.toLowerCase()) {
-                address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
-                this._offset = this._offset + 4;
-              } else {
-                address0 = FAILURE;
-                if (this._offset > this._failure) {
-                  this._failure = this._offset;
-                  this._expected = [];
-                }
-                if (this._offset === this._failure) {
-                  this._expected.push('`show`');
-                }
-              }
-              if (address0 === FAILURE) {
-                this._offset = index1;
-                var chunk5 = null;
-                if (this._offset < this._inputSize) {
-                  chunk5 = this._input.substring(this._offset, this._offset + 4);
-                }
-                if (chunk5 !== null && chunk5.toLowerCase() === 'list'.toLowerCase()) {
-                  address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
-                  this._offset = this._offset + 4;
-                } else {
-                  address0 = FAILURE;
-                  if (this._offset > this._failure) {
-                    this._failure = this._offset;
-                    this._expected = [];
-                  }
-                  if (this._offset === this._failure) {
-                    this._expected.push('`list`');
-                  }
-                }
-                if (address0 === FAILURE) {
-                  this._offset = index1;
-                  var chunk6 = null;
-                  if (this._offset < this._inputSize) {
-                    chunk6 = this._input.substring(this._offset, this._offset + 6);
-                  }
-                  if (chunk6 !== null && chunk6.toLowerCase() === 'delete'.toLowerCase()) {
-                    address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
-                    this._offset = this._offset + 6;
-                  } else {
-                    address0 = FAILURE;
-                    if (this._offset > this._failure) {
-                      this._failure = this._offset;
-                      this._expected = [];
-                    }
-                    if (this._offset === this._failure) {
-                      this._expected.push('`delete`');
-                    }
-                  }
-                  if (address0 === FAILURE) {
-                    this._offset = index1;
-                    var chunk7 = null;
-                    if (this._offset < this._inputSize) {
-                      chunk7 = this._input.substring(this._offset, this._offset + 7);
-                    }
-                    if (chunk7 !== null && chunk7.toLowerCase() === 'decline'.toLowerCase()) {
-                      address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
-                      this._offset = this._offset + 7;
-                    } else {
-                      address0 = FAILURE;
-                      if (this._offset > this._failure) {
-                        this._failure = this._offset;
-                        this._expected = [];
-                      }
-                      if (this._offset === this._failure) {
-                        this._expected.push('`decline`');
-                      }
-                    }
-                    if (address0 === FAILURE) {
-                      this._offset = index1;
-                      var chunk8 = null;
-                      if (this._offset < this._inputSize) {
-                        chunk8 = this._input.substring(this._offset, this._offset + 7);
-                      }
-                      if (chunk8 !== null && chunk8.toLowerCase() === 'approve'.toLowerCase()) {
-                        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
-                        this._offset = this._offset + 7;
-                      } else {
-                        address0 = FAILURE;
-                        if (this._offset > this._failure) {
-                          this._failure = this._offset;
-                          this._expected = [];
-                        }
-                        if (this._offset === this._failure) {
-                          this._expected.push('`approve`');
-                        }
-                      }
-                      if (address0 === FAILURE) {
-                        this._offset = index1;
-                        var chunk9 = null;
-                        if (this._offset < this._inputSize) {
-                          chunk9 = this._input.substring(this._offset, this._offset + 7);
-                        }
-                        if (chunk9 !== null && chunk9.toLowerCase() === 'discuss'.toLowerCase()) {
-                          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
-                          this._offset = this._offset + 7;
-                        } else {
-                          address0 = FAILURE;
-                          if (this._offset > this._failure) {
-                            this._failure = this._offset;
-                            this._expected = [];
-                          }
-                          if (this._offset === this._failure) {
-                            this._expected.push('`discuss`');
-                          }
-                        }
-                        if (address0 === FAILURE) {
-                          this._offset = index1;
-                          var chunk10 = null;
-                          if (this._offset < this._inputSize) {
-                            chunk10 = this._input.substring(this._offset, this._offset + 7);
-                          }
-                          if (chunk10 !== null && chunk10.toLowerCase() === 'suggest'.toLowerCase()) {
-                            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
-                            this._offset = this._offset + 7;
-                          } else {
-                            address0 = FAILURE;
-                            if (this._offset > this._failure) {
-                              this._failure = this._offset;
-                              this._expected = [];
-                            }
-                            if (this._offset === this._failure) {
-                              this._expected.push('`suggest`');
-                            }
-                          }
-                          if (address0 === FAILURE) {
-                            this._offset = index1;
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
             }
+          } else {
+            elements0 = null;
+            this._offset = index1;
           }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode7(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_list[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct_list: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct_list = this._cache._speechAct_list || {};
+      var cached = this._cache._speechAct_list[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 4);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'list'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+        this._offset = this._offset + 4;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`list`');
         }
       }
-      this._cache._speechAct[index0] = [address0, this._offset];
+      this._cache._speechAct_list[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_show_entity: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_show_entity = this._cache._msg_show_entity || {};
+      var cached = this._cache._msg_show_entity[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(5);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_show();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode8(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_show_entity[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_show: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_show = this._cache._msg_show || {};
+      var cached = this._cache._msg_show[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(4);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_show();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            var index2 = this._offset;
+            var chunk0 = null;
+            if (this._offset < this._inputSize) {
+              chunk0 = this._input.substring(this._offset, this._offset + 1);
+            }
+            if (chunk0 !== null && chunk0.toLowerCase() === 's'.toLowerCase()) {
+              address4 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+              this._offset = this._offset + 1;
+            } else {
+              address4 = FAILURE;
+              if (this._offset > this._failure) {
+                this._failure = this._offset;
+                this._expected = [];
+              }
+              if (this._offset === this._failure) {
+                this._expected.push('`s`');
+              }
+            }
+            if (address4 === FAILURE) {
+              address4 = new TreeNode(this._input.substring(index2, index2), index2);
+              this._offset = index2;
+            }
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode9(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_show[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct_show: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct_show = this._cache._speechAct_show || {};
+      var cached = this._cache._speechAct_show[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 4);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'show'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+        this._offset = this._offset + 4;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`show`');
+        }
+      }
+      this._cache._speechAct_show[index0] = [address0, this._offset];
       return address0;
     },
 
@@ -658,28 +1356,41 @@
       return address0;
     },
 
-    _read_text: function() {
+    _read_entityText: function() {
       var address0 = FAILURE, index0 = this._offset;
-      this._cache._text = this._cache._text || {};
-      var cached = this._cache._text[index0];
+      this._cache._entityText = this._cache._entityText || {};
+      var cached = this._cache._entityText[index0];
       if (cached) {
         this._offset = cached[1];
         return cached[0];
       }
-      if (this._offset < this._inputSize) {
-        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
-        this._offset = this._offset + 1;
-      } else {
-        address0 = FAILURE;
-        if (this._offset > this._failure) {
-          this._failure = this._offset;
-          this._expected = [];
+      var remaining0 = 1, index1 = this._offset, elements0 = [], address1 = true;
+      while (address1 !== FAILURE) {
+        if (this._offset < this._inputSize) {
+          address1 = new TreeNode(this._input.substring(this._offset, this._offset + 1), this._offset);
+          this._offset = this._offset + 1;
+        } else {
+          address1 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('<any char>');
+          }
         }
-        if (this._offset === this._failure) {
-          this._expected.push('<any char>');
+        if (address1 !== FAILURE) {
+          elements0.push(address1);
+          --remaining0;
         }
       }
-      this._cache._text[index0] = [address0, this._offset];
+      if (remaining0 <= 0) {
+        address0 = new TreeNode(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      } else {
+        address0 = FAILURE;
+      }
+      this._cache._entityText[index0] = [address0, this._offset];
       return address0;
     },
 
@@ -691,7 +1402,7 @@
         this._offset = cached[1];
         return cached[0];
       }
-      var remaining0 = 0, index1 = this._offset, elements0 = [], address1 = true;
+      var remaining0 = 1, index1 = this._offset, elements0 = [], address1 = true;
       while (address1 !== FAILURE) {
         var index2 = this._offset;
         var chunk0 = null;

--- a/src/protocols/entityChat.js
+++ b/src/protocols/entityChat.js
@@ -82,7 +82,7 @@
 
   var TreeNode4 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_create_team'] = elements[0];
+    this['speechAct_create'] = elements[0];
     this['__'] = elements[3];
     this['entityType_team'] = elements[2];
     this['entityId'] = elements[4];
@@ -644,7 +644,7 @@
       }
       var index1 = this._offset, elements0 = new Array(5);
       var address1 = FAILURE;
-      address1 = this._read_speechAct_create_team();
+      address1 = this._read_speechAct_create();
       if (address1 !== FAILURE) {
         elements0[0] = address1;
         var address2 = FAILURE;

--- a/src/protocols/entityChat.js
+++ b/src/protocols/entityChat.js
@@ -53,9 +53,9 @@
 
   var TreeNode1 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_create'] = elements[0];
+    this['speechAct_suggest'] = elements[0];
     this['__'] = elements[5];
-    this['entityType'] = elements[2];
+    this['entityType_suggest'] = elements[2];
     this['entityId'] = elements[4];
     this['entityText'] = elements[6];
   };
@@ -63,47 +63,75 @@
 
   var TreeNode2 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_update'] = elements[0];
-    this['__'] = elements[3];
-    this['entityType'] = elements[2];
+    this['speechAct_add'] = elements[0];
+    this['__'] = elements[5];
+    this['entityType_add'] = elements[2];
     this['entityId'] = elements[4];
+    this['entityText'] = elements[6];
   };
   inherit(TreeNode2, TreeNode);
 
   var TreeNode3 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_join'] = elements[0];
+    this['speechAct_add'] = elements[0];
     this['__'] = elements[3];
-    this['entityType_join'] = elements[2];
+    this['entityType_add'] = elements[2];
     this['entityId'] = elements[4];
   };
   inherit(TreeNode3, TreeNode);
 
   var TreeNode4 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_invite'] = elements[0];
+    this['speechAct_create_team'] = elements[0];
     this['__'] = elements[3];
-    this['entityType_invite'] = elements[2];
+    this['entityType_team'] = elements[2];
     this['entityId'] = elements[4];
   };
   inherit(TreeNode4, TreeNode);
 
   var TreeNode5 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
-    this['speechAct_list'] = elements[0];
-    this['__'] = elements[1];
+    this['speechAct_update'] = elements[0];
+    this['__'] = elements[3];
     this['entityType'] = elements[2];
+    this['entityId'] = elements[4];
   };
   inherit(TreeNode5, TreeNode);
 
   var TreeNode6 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_join'] = elements[0];
+    this['__'] = elements[3];
+    this['entityType_join'] = elements[2];
+    this['entityId'] = elements[4];
+  };
+  inherit(TreeNode6, TreeNode);
+
+  var TreeNode7 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_invite'] = elements[0];
+    this['__'] = elements[3];
+    this['entityType_invite'] = elements[2];
+    this['entityId'] = elements[4];
+  };
+  inherit(TreeNode7, TreeNode);
+
+  var TreeNode8 = function(text, offset, elements) {
+    TreeNode.apply(this, arguments);
+    this['speechAct_list'] = elements[0];
+    this['__'] = elements[1];
+    this['entityType'] = elements[2];
+  };
+  inherit(TreeNode8, TreeNode);
+
+  var TreeNode9 = function(text, offset, elements) {
     TreeNode.apply(this, arguments);
     this['speechAct_show'] = elements[0];
     this['__'] = elements[3];
     this['entityType'] = elements[2];
     this['entityId'] = elements[4];
   };
-  inherit(TreeNode6, TreeNode);
+  inherit(TreeNode9, TreeNode);
 
   var FAILURE = {};
 
@@ -117,24 +145,36 @@
         return cached[0];
       }
       var index1 = this._offset;
-      address0 = this._read_msg_create();
+      address0 = this._read_msg_suggest();
       if (address0 === FAILURE) {
         this._offset = index1;
-        address0 = this._read_msg_update();
+        address0 = this._read_msg_add_member_full();
         if (address0 === FAILURE) {
           this._offset = index1;
-          address0 = this._read_msg_join();
+          address0 = this._read_msg_add_member();
           if (address0 === FAILURE) {
             this._offset = index1;
-            address0 = this._read_msg_invite();
+            address0 = this._read_msg_create_team();
             if (address0 === FAILURE) {
               this._offset = index1;
-              address0 = this._read_msg_list();
+              address0 = this._read_msg_update();
               if (address0 === FAILURE) {
                 this._offset = index1;
-                address0 = this._read_msg_show();
+                address0 = this._read_msg_join();
                 if (address0 === FAILURE) {
                   this._offset = index1;
+                  address0 = this._read_msg_invite();
+                  if (address0 === FAILURE) {
+                    this._offset = index1;
+                    address0 = this._read_msg_list();
+                    if (address0 === FAILURE) {
+                      this._offset = index1;
+                      address0 = this._read_msg_show();
+                      if (address0 === FAILURE) {
+                        this._offset = index1;
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -145,17 +185,17 @@
       return address0;
     },
 
-    _read_msg_create: function() {
+    _read_msg_suggest: function() {
       var address0 = FAILURE, index0 = this._offset;
-      this._cache._msg_create = this._cache._msg_create || {};
-      var cached = this._cache._msg_create[index0];
+      this._cache._msg_suggest = this._cache._msg_suggest || {};
+      var cached = this._cache._msg_suggest[index0];
       if (cached) {
         this._offset = cached[1];
         return cached[0];
       }
       var index1 = this._offset, elements0 = new Array(7);
       var address1 = FAILURE;
-      address1 = this._read_speechAct_create();
+      address1 = this._read_speechAct_suggest();
       if (address1 !== FAILURE) {
         elements0[0] = address1;
         var address2 = FAILURE;
@@ -163,7 +203,7 @@
         if (address2 !== FAILURE) {
           elements0[1] = address2;
           var address3 = FAILURE;
-          address3 = this._read_entityType();
+          address3 = this._read_entityType_suggest();
           if (address3 !== FAILURE) {
             elements0[2] = address3;
             var address4 = FAILURE;
@@ -216,7 +256,440 @@
         address0 = new TreeNode1(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
-      this._cache._msg_create[index0] = [address0, this._offset];
+      this._cache._msg_suggest[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct_suggest: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct_suggest = this._cache._speechAct_suggest || {};
+      var cached = this._cache._speechAct_suggest[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 7);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'suggest'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+        this._offset = this._offset + 7;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`suggest`');
+        }
+      }
+      this._cache._speechAct_suggest[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_entityType_suggest: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._entityType_suggest = this._cache._entityType_suggest || {};
+      var cached = this._cache._entityType_suggest[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset;
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 7);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'purpose'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
+        this._offset = this._offset + 7;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`purpose`');
+        }
+      }
+      if (address0 === FAILURE) {
+        this._offset = index1;
+        var chunk1 = null;
+        if (this._offset < this._inputSize) {
+          chunk1 = this._input.substring(this._offset, this._offset + 4);
+        }
+        if (chunk1 !== null && chunk1.toLowerCase() === 'logo'.toLowerCase()) {
+          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+          this._offset = this._offset + 4;
+        } else {
+          address0 = FAILURE;
+          if (this._offset > this._failure) {
+            this._failure = this._offset;
+            this._expected = [];
+          }
+          if (this._offset === this._failure) {
+            this._expected.push('`logo`');
+          }
+        }
+        if (address0 === FAILURE) {
+          this._offset = index1;
+          var chunk2 = null;
+          if (this._offset < this._inputSize) {
+            chunk2 = this._input.substring(this._offset, this._offset + 4);
+          }
+          if (chunk2 !== null && chunk2.toLowerCase() === 'name'.toLowerCase()) {
+            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+            this._offset = this._offset + 4;
+          } else {
+            address0 = FAILURE;
+            if (this._offset > this._failure) {
+              this._failure = this._offset;
+              this._expected = [];
+            }
+            if (this._offset === this._failure) {
+              this._expected.push('`name`');
+            }
+          }
+          if (address0 === FAILURE) {
+            this._offset = index1;
+            var chunk3 = null;
+            if (this._offset < this._inputSize) {
+              chunk3 = this._input.substring(this._offset, this._offset + 11);
+            }
+            if (chunk3 !== null && chunk3.toLowerCase() === 'description'.toLowerCase()) {
+              address0 = new TreeNode(this._input.substring(this._offset, this._offset + 11), this._offset);
+              this._offset = this._offset + 11;
+            } else {
+              address0 = FAILURE;
+              if (this._offset > this._failure) {
+                this._failure = this._offset;
+                this._expected = [];
+              }
+              if (this._offset === this._failure) {
+                this._expected.push('`description`');
+              }
+            }
+            if (address0 === FAILURE) {
+              this._offset = index1;
+              var chunk4 = null;
+              if (this._offset < this._inputSize) {
+                chunk4 = this._input.substring(this._offset, this._offset + 5);
+              }
+              if (chunk4 !== null && chunk4.toLowerCase() === 'intro'.toLowerCase()) {
+                address0 = new TreeNode(this._input.substring(this._offset, this._offset + 5), this._offset);
+                this._offset = this._offset + 5;
+              } else {
+                address0 = FAILURE;
+                if (this._offset > this._failure) {
+                  this._failure = this._offset;
+                  this._expected = [];
+                }
+                if (this._offset === this._failure) {
+                  this._expected.push('`intro`');
+                }
+              }
+              if (address0 === FAILURE) {
+                this._offset = index1;
+                var chunk5 = null;
+                if (this._offset < this._inputSize) {
+                  chunk5 = this._input.substring(this._offset, this._offset + 3);
+                }
+                if (chunk5 !== null && chunk5.toLowerCase() === 'tag'.toLowerCase()) {
+                  address0 = new TreeNode(this._input.substring(this._offset, this._offset + 3), this._offset);
+                  this._offset = this._offset + 3;
+                } else {
+                  address0 = FAILURE;
+                  if (this._offset > this._failure) {
+                    this._failure = this._offset;
+                    this._expected = [];
+                  }
+                  if (this._offset === this._failure) {
+                    this._expected.push('`tag`');
+                  }
+                }
+                if (address0 === FAILURE) {
+                  this._offset = index1;
+                  var chunk6 = null;
+                  if (this._offset < this._inputSize) {
+                    chunk6 = this._input.substring(this._offset, this._offset + 4);
+                  }
+                  if (chunk6 !== null && chunk6.toLowerCase() === 'tool'.toLowerCase()) {
+                    address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+                    this._offset = this._offset + 4;
+                  } else {
+                    address0 = FAILURE;
+                    if (this._offset > this._failure) {
+                      this._failure = this._offset;
+                      this._expected = [];
+                    }
+                    if (this._offset === this._failure) {
+                      this._expected.push('`tool`');
+                    }
+                  }
+                  if (address0 === FAILURE) {
+                    this._offset = index1;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      this._cache._entityType_suggest[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_add_member_full: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_add_member_full = this._cache._msg_add_member_full || {};
+      var cached = this._cache._msg_add_member_full[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(7);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_add();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType_add();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+                var address6 = FAILURE;
+                address6 = this._read___();
+                if (address6 !== FAILURE) {
+                  elements0[5] = address6;
+                  var address7 = FAILURE;
+                  address7 = this._read_entityText();
+                  if (address7 !== FAILURE) {
+                    elements0[6] = address7;
+                  } else {
+                    elements0 = null;
+                    this._offset = index1;
+                  }
+                } else {
+                  elements0 = null;
+                  this._offset = index1;
+                }
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode2(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_add_member_full[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_speechAct_add: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._speechAct_add = this._cache._speechAct_add || {};
+      var cached = this._cache._speechAct_add[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 3);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'add'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 3), this._offset);
+        this._offset = this._offset + 3;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`add`');
+        }
+      }
+      this._cache._speechAct_add[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_entityType_add: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._entityType_add = this._cache._entityType_add || {};
+      var cached = this._cache._entityType_add[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 6);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'member'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 6), this._offset);
+        this._offset = this._offset + 6;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
+        }
+        if (this._offset === this._failure) {
+          this._expected.push('`member`');
+        }
+      }
+      this._cache._entityType_add[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_add_member: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_add_member = this._cache._msg_add_member || {};
+      var cached = this._cache._msg_add_member[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(5);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_add();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType_add();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode3(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_add_member[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_msg_create_team: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._msg_create_team = this._cache._msg_create_team || {};
+      var cached = this._cache._msg_create_team[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var index1 = this._offset, elements0 = new Array(5);
+      var address1 = FAILURE;
+      address1 = this._read_speechAct_create_team();
+      if (address1 !== FAILURE) {
+        elements0[0] = address1;
+        var address2 = FAILURE;
+        address2 = this._read___();
+        if (address2 !== FAILURE) {
+          elements0[1] = address2;
+          var address3 = FAILURE;
+          address3 = this._read_entityType_team();
+          if (address3 !== FAILURE) {
+            elements0[2] = address3;
+            var address4 = FAILURE;
+            address4 = this._read___();
+            if (address4 !== FAILURE) {
+              elements0[3] = address4;
+              var address5 = FAILURE;
+              address5 = this._read_entityId();
+              if (address5 !== FAILURE) {
+                elements0[4] = address5;
+              } else {
+                elements0 = null;
+                this._offset = index1;
+              }
+            } else {
+              elements0 = null;
+              this._offset = index1;
+            }
+          } else {
+            elements0 = null;
+            this._offset = index1;
+          }
+        } else {
+          elements0 = null;
+          this._offset = index1;
+        }
+      } else {
+        elements0 = null;
+        this._offset = index1;
+      }
+      if (elements0 === null) {
+        address0 = FAILURE;
+      } else {
+        address0 = new TreeNode4(this._input.substring(index1, this._offset), index1, elements0);
+        this._offset = this._offset;
+      }
+      this._cache._msg_create_team[index0] = [address0, this._offset];
       return address0;
     },
 
@@ -228,7 +701,6 @@
         this._offset = cached[1];
         return cached[0];
       }
-      var index1 = this._offset;
       var chunk0 = null;
       if (this._offset < this._inputSize) {
         chunk0 = this._input.substring(this._offset, this._offset + 6);
@@ -246,50 +718,36 @@
           this._expected.push('`create`');
         }
       }
-      if (address0 === FAILURE) {
-        this._offset = index1;
-        var chunk1 = null;
-        if (this._offset < this._inputSize) {
-          chunk1 = this._input.substring(this._offset, this._offset + 3);
+      this._cache._speechAct_create[index0] = [address0, this._offset];
+      return address0;
+    },
+
+    _read_entityType_team: function() {
+      var address0 = FAILURE, index0 = this._offset;
+      this._cache._entityType_team = this._cache._entityType_team || {};
+      var cached = this._cache._entityType_team[index0];
+      if (cached) {
+        this._offset = cached[1];
+        return cached[0];
+      }
+      var chunk0 = null;
+      if (this._offset < this._inputSize) {
+        chunk0 = this._input.substring(this._offset, this._offset + 4);
+      }
+      if (chunk0 !== null && chunk0.toLowerCase() === 'team'.toLowerCase()) {
+        address0 = new TreeNode(this._input.substring(this._offset, this._offset + 4), this._offset);
+        this._offset = this._offset + 4;
+      } else {
+        address0 = FAILURE;
+        if (this._offset > this._failure) {
+          this._failure = this._offset;
+          this._expected = [];
         }
-        if (chunk1 !== null && chunk1.toLowerCase() === 'add'.toLowerCase()) {
-          address0 = new TreeNode(this._input.substring(this._offset, this._offset + 3), this._offset);
-          this._offset = this._offset + 3;
-        } else {
-          address0 = FAILURE;
-          if (this._offset > this._failure) {
-            this._failure = this._offset;
-            this._expected = [];
-          }
-          if (this._offset === this._failure) {
-            this._expected.push('`add`');
-          }
-        }
-        if (address0 === FAILURE) {
-          this._offset = index1;
-          var chunk2 = null;
-          if (this._offset < this._inputSize) {
-            chunk2 = this._input.substring(this._offset, this._offset + 7);
-          }
-          if (chunk2 !== null && chunk2.toLowerCase() === 'suggest'.toLowerCase()) {
-            address0 = new TreeNode(this._input.substring(this._offset, this._offset + 7), this._offset);
-            this._offset = this._offset + 7;
-          } else {
-            address0 = FAILURE;
-            if (this._offset > this._failure) {
-              this._failure = this._offset;
-              this._expected = [];
-            }
-            if (this._offset === this._failure) {
-              this._expected.push('`suggest`');
-            }
-          }
-          if (address0 === FAILURE) {
-            this._offset = index1;
-          }
+        if (this._offset === this._failure) {
+          this._expected.push('`team`');
         }
       }
-      this._cache._speechAct_create[index0] = [address0, this._offset];
+      this._cache._entityType_team[index0] = [address0, this._offset];
       return address0;
     },
 
@@ -345,7 +803,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode2(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode5(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_update[index0] = [address0, this._offset];
@@ -497,7 +955,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode3(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode6(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_join[index0] = [address0, this._offset];
@@ -614,7 +1072,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode4(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode7(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_invite[index0] = [address0, this._offset];
@@ -744,7 +1202,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode5(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode8(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_list[index0] = [address0, this._offset];
@@ -832,7 +1290,7 @@
       if (elements0 === null) {
         address0 = FAILURE;
       } else {
-        address0 = new TreeNode6(this._input.substring(index1, this._offset), index1, elements0);
+        address0 = new TreeNode9(this._input.substring(index1, this._offset), index1, elements0);
         this._offset = this._offset;
       }
       this._cache._msg_show[index0] = [address0, this._offset];

--- a/src/protocols/entityChat.peg
+++ b/src/protocols/entityChat.peg
@@ -1,10 +1,8 @@
 grammar EntityChat
 
-message              <-  msg_create_full / msg_create_with_id / msg_create / msg_update / msg_join / msg_invite / msg_list / msg_show
+message              <-  msg_create / msg_update / msg_join / msg_invite / msg_list / msg_show
 
-msg_create           <-  speechAct_create __ entityType
-msg_create_with_id   <-  speechAct_create __ entityType __ entityId
-msg_create_full      <-  speechAct_create __ entityType __ entityId __ entityText
+msg_create           <-  speechAct_create __ entityType __ entityId __ entityText
 speechAct_create     <-  `create` / `add` / `suggest`
 
 msg_update           <-  speechAct_update __ entityType __ entityId

--- a/src/protocols/entityChat.peg
+++ b/src/protocols/entityChat.peg
@@ -1,8 +1,31 @@
 grammar EntityChat
 
-message        <-  speechAct __ entityType __ entityId __? text?
-speechAct      <-  `join` / `create` / `add` / `invite` / `show` / `list` / `delete` / `decline` / `approve` / `discuss` / `suggest`
-entityType     <-  `purpose` / `logo` / `name` / `description` / `intro` / `tag` / `tool` / `member` / `team`
-entityId       <-  (!" " .)*
-text           <-  .
-__             <-  (" " / [\n\r\t])*
+message              <-  msg_create_full / msg_create_with_id / msg_create / msg_update / msg_join / msg_invite / msg_list / msg_show_entity / msg_show
+
+msg_create           <-  speechAct_create __ entityType
+msg_create_with_id   <-  speechAct_create __ entityType __ entityId
+msg_create_full      <-  speechAct_create __ entityType __ entityId __ entityText
+speechAct_create     <-  `create` / `add` / `suggest`
+
+msg_update           <-  speechAct_update __ entityType __ entityId
+speechAct_update     <-  `decline` / `approve` / `discuss` / `delete`
+
+msg_join             <-  speechAct_join __ entityType_join __ entityId
+speechAct_join       <-  `join`
+entityType_join      <-  `team`
+
+msg_invite           <-  speechAct_invite __ entityType_invite __ entityId
+speechAct_invite     <-  `invite`
+entityType_invite    <-  `member`
+
+msg_list             <-  speechAct_list __ entityType `s`?
+speechAct_list       <-  `list`
+
+msg_show_entity      <-  speechAct_show __ entityType __ entityId
+msg_show             <-  speechAct_show __ entityType `s`?
+speechAct_show       <-  `show`
+
+entityType           <-  `purpose` / `logo` / `name` / `description` / `intro` / `tag` / `tool` / `member` / `team`
+entityId             <-  (!" " .)*
+entityText           <-  (.)+
+__                   <-  (" " / [\n\r\t])+

--- a/src/protocols/entityChat.peg
+++ b/src/protocols/entityChat.peg
@@ -1,0 +1,8 @@
+grammar EntityChat
+
+message        <-  speechAct __ entityType __ entityId __? text?
+speechAct      <-  `join` / `create` / `add` / `invite` / `show` / `list` / `delete` / `decline` / `approve` / `discuss` / `suggest`
+entityType     <-  `purpose` / `logo` / `name` / `description` / `intro` / `tag` / `tool` / `member` / `team`
+entityId       <-  (!" " .)*
+text           <-  .
+__             <-  (" " / [\n\r\t])*

--- a/src/protocols/entityChat.peg
+++ b/src/protocols/entityChat.peg
@@ -1,9 +1,20 @@
 grammar EntityChat
 
-message              <-  msg_create / msg_update / msg_join / msg_invite / msg_list / msg_show
+message              <-  msg_suggest / msg_add_member_full / msg_add_member / msg_create_team / msg_update / msg_join / msg_invite / msg_list / msg_show
 
-msg_create           <-  speechAct_create __ entityType __ entityId __ entityText
-speechAct_create     <-  `create` / `add` / `suggest`
+msg_suggest          <-  speechAct_suggest __ entityType_suggest __ entityId __ entityText
+speechAct_suggest    <-  `suggest`
+entityType_suggest   <-  `purpose` / `logo` / `name` / `description` / `intro` / `tag` / `tool`
+
+msg_add_member_full  <-  speechAct_add __ entityType_add __ entityId __ entityText
+speechAct_add        <-  `add`
+entityType_add       <-  `member`
+
+msg_add_member       <-  speechAct_add __ entityType_add __ entityId
+
+msg_create_team      <-  speechAct_create_team __ entityType_team __ entityId
+speechAct_create     <-  `create`
+entityType_team      <-  `team`
 
 msg_update           <-  speechAct_update __ entityType __ entityId
 speechAct_update     <-  `decline` / `approve` / `discuss` / `delete`

--- a/src/protocols/entityChat.peg
+++ b/src/protocols/entityChat.peg
@@ -12,7 +12,7 @@ entityType_add       <-  `member`
 
 msg_add_member       <-  speechAct_add __ entityType_add __ entityId
 
-msg_create_team      <-  speechAct_create_team __ entityType_team __ entityId
+msg_create_team      <-  speechAct_create __ entityType_team __ entityId
 speechAct_create     <-  `create`
 entityType_team      <-  `team`
 

--- a/src/protocols/entityChat.peg
+++ b/src/protocols/entityChat.peg
@@ -1,6 +1,6 @@
 grammar EntityChat
 
-message              <-  msg_create_full / msg_create_with_id / msg_create / msg_update / msg_join / msg_invite / msg_list / msg_show_entity / msg_show
+message              <-  msg_create_full / msg_create_with_id / msg_create / msg_update / msg_join / msg_invite / msg_list / msg_show
 
 msg_create           <-  speechAct_create __ entityType
 msg_create_with_id   <-  speechAct_create __ entityType __ entityId
@@ -21,11 +21,10 @@ entityType_invite    <-  `member`
 msg_list             <-  speechAct_list __ entityType `s`?
 speechAct_list       <-  `list`
 
-msg_show_entity      <-  speechAct_show __ entityType __ entityId
-msg_show             <-  speechAct_show __ entityType `s`?
+msg_show             <-  speechAct_show __ entityType __ entityId
 speechAct_show       <-  `show`
 
 entityType           <-  `purpose` / `logo` / `name` / `description` / `intro` / `tag` / `tool` / `member` / `team`
-entityId             <-  (!" " .)*
+entityId             <-  (!" " .)+
 entityText           <-  (.)+
 __                   <-  (" " / [\n\r\t])+


### PR DESCRIPTION
#### Why
I want to make the chat input component slightly more user friendly, e.g., by allowing entering messages by writing them, instead of using the drop-down selections.

#### What
* Added the option to enter messages as text
* Added a protocol parser that verifies that the text complies with the protocol & indicate it to the user
* Changed the drop-down components to be just ways to look up values. Once you select a value it is added to the message text
* Added a drop-down showing entity id's for the current team, to make it easier to update an entity
* Removed the "send" button - users can use the "return" key to send the message

